### PR TITLE
Update Consul cookbook to 1.4.3

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,4 @@ suites:
       - recipe[scpr-consul-test::web_service]
     attributes:
       consul:
-        service_mode: server
-        service_user: root
-        service_group: root
+        service_mode: bootstrap

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,9 @@ include_attribute 'consul'
 
 default.consul.servers        = ['127.0.0.1']
 
-# FIXME: need to see why consul cookbook sets the agent to run as root
+# FIXME: this is a by-product of how an old version of the consul cookbook
+# used to set up the consul service. it now uses 'consul', but we're still
+# on 'root' because we haven't taken the time to assess the change
 default.consul.service_user   = 'root'
 default.consul.service_group  = 'root'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,8 @@ maintainer_email 'erichardson@scpr.org'
 license          'all_rights'
 description      'Installs/Configures scpr-consul'
 long_description 'Installs/Configures scpr-consul'
-version          '0.2.0'
+version          '0.3.0'
 
-depends "consul", "~> 0.11"
+depends "consul", "~> 1.4"
 depends "consul-template", "~> 0.8.0"
 depends "dnsmasq"

--- a/providers/web_service.rb
+++ b/providers/web_service.rb
@@ -21,20 +21,21 @@ action :create do
     })
   end
 
-  consul_service_def svc_name do
-    action    :create
-    check({
-      interval: '5s',
-      script:   "#{node.scpr_consul.checks_dir}/#{new_resource.name}"
+  consul_definition svc_name do
+    action :create
+    type 'service'
+    user node.consul.service_user
+    group node.consul.service_group
+    parameters({
+      port: new_resource.port.to_i,
+      checks: [{
+        interval: '5s',
+        script:   "#{node.scpr_consul.checks_dir}/#{new_resource.name}",
+      }],
+      tags: new_resource.tags||[],
     })
 
-    port      new_resource.port.to_i
-
-    if new_resource.tags
-      tags      new_resource.tags
-    end
-
-    notifies  :reload, "service[consul]"
+    notifies  :reload, "consul_service[consul]", :delayed
   end
 
 end


### PR DESCRIPTION
This change is necessary to pick up a change in where Consul binaries are hosted, but the >1.0 Consul cookbook changes `consul_service_def` to `consul_definition`, so this is a breaking change that requires coordination.

Cookbooks that would need to be updated:
- [ ] scpr-apps
- [ ] scpr-elasticsearch
- [ ] scpr-logstash
- [ ] scpr-media-nfs
- [ ] scpr-memcached
- [ ] scpr-percona-cluster
- [ ] scpr-prometheus-client
- [ ] scpr-riakcs
- [ ] scpr-rundeck
